### PR TITLE
image: support loading and pruning images

### DIFF
--- a/image.go
+++ b/image.go
@@ -2,7 +2,7 @@ package docker
 
 import "github.com/cpuguy83/go-docker/image"
 
-// ImageService provides access to image functionaliaty, such as create, list.
+// ImageService provides access to image functionality, such as create, list.
 func (c *Client) ImageService() *image.Service {
 	return image.NewService(c.tr)
 }

--- a/image/create.go
+++ b/image/create.go
@@ -16,6 +16,7 @@ type CreateConfig struct {
 	Repo      string
 	Tag       string
 	Platform  string
+	Changes   string
 }
 
 // CreateOption is used as functional arguments to create images.
@@ -35,6 +36,7 @@ func (s *Service) Create(ctx context.Context, opts ...CreateOption) error {
 		q.Add("repo", cfg.Repo)
 		q.Add("tag", cfg.Tag)
 		q.Add("platform", cfg.Platform)
+		q.Add("changes", cfg.Changes)
 		req.URL.RawQuery = q.Encode()
 		return nil
 	}

--- a/image/create.go
+++ b/image/create.go
@@ -16,7 +16,7 @@ type CreateConfig struct {
 	Repo      string
 	Tag       string
 	Platform  string
-	Changes   string
+	Changes   []string
 }
 
 // CreateOption is used as functional arguments to create images.
@@ -36,7 +36,9 @@ func (s *Service) Create(ctx context.Context, opts ...CreateOption) error {
 		q.Add("repo", cfg.Repo)
 		q.Add("tag", cfg.Tag)
 		q.Add("platform", cfg.Platform)
-		q.Add("changes", cfg.Changes)
+		for _, c := range cfg.Changes {
+			q.Add("changes", c)
+		}
 		req.URL.RawQuery = q.Encode()
 		return nil
 	}

--- a/image/export.go
+++ b/image/export.go
@@ -1,0 +1,48 @@
+package image
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/cpuguy83/go-docker/httputil"
+	"github.com/cpuguy83/go-docker/version"
+)
+
+// ExportBundleConfig holds the options for exporting images.
+type ExportBundleConfig struct {
+	Names []string
+}
+
+// ExportBundleOption is used as functional arguments to export images.
+// ExportBundleOption configure a ExportBundleConfig.
+type ExportBundleOption func(config *ExportBundleConfig)
+
+func (s *Service) ExportBundle(ctx context.Context, opts ...ExportBundleOption) ([]byte, error) {
+	cfg := ExportBundleConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	withExportBundleConfig := func(req *http.Request) error {
+		q := req.URL.Query()
+		q.Add("names", strings.Join(cfg.Names, ","))
+		req.URL.RawQuery = q.Encode()
+		return nil
+	}
+
+	resp, err := httputil.DoRequest(ctx, func(ctx context.Context) (*http.Response, error) {
+		return s.tr.Do(ctx, http.MethodGet, version.Join(ctx, "/images/get"), withExportBundleConfig)
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/image/export.go
+++ b/image/export.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"github.com/cpuguy83/go-docker/httputil"
 	"github.com/cpuguy83/go-docker/version"
@@ -27,7 +26,9 @@ func (s *Service) ExportBundle(ctx context.Context, opts ...ExportBundleOption) 
 
 	withExportBundleConfig := func(req *http.Request) error {
 		q := req.URL.Query()
-		q.Add("names", strings.Join(cfg.Names, ","))
+		for _, name := range cfg.Names {
+			q.Add("names", name)
+		}
 		req.URL.RawQuery = q.Encode()
 		return nil
 	}

--- a/image/imageapi/prune.go
+++ b/image/imageapi/prune.go
@@ -1,0 +1,11 @@
+package imageapi
+
+type Prune struct {
+	ImagesDeleted  []DeletedImage
+	SpaceReclaimed int64
+}
+
+type DeletedImage struct {
+	Untagged string
+	Deleted  string
+}

--- a/image/load.go
+++ b/image/load.go
@@ -1,0 +1,46 @@
+package image
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/cpuguy83/go-docker/httputil"
+	"github.com/cpuguy83/go-docker/version"
+	"github.com/pkg/errors"
+)
+
+// LoadConfig holds the options for loading images.
+type LoadConfig struct {
+	Quiet bool
+}
+
+// LoadOption is used as functional arguments to list images. LoadOption
+// configure a LoadConfig.
+type LoadOption func(config *LoadConfig)
+
+// Load loads container images.
+func (s *Service) Load(ctx context.Context, tar io.ReadCloser, opts ...LoadOption) error {
+	cfg := LoadConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	withListConfig := func(req *http.Request) error {
+		q := req.URL.Query()
+		q.Add("quiet", strconv.FormatBool(cfg.Quiet))
+		req.URL.RawQuery = q.Encode()
+		req.Body = tar
+		return nil
+	}
+
+	resp, err := httputil.DoRequest(ctx, func(ctx context.Context) (*http.Response, error) {
+		return s.tr.Do(ctx, http.MethodPost, version.Join(ctx, "/images/load"), withListConfig)
+	})
+	if err != nil {
+		return errors.Wrap(err, "error loading images")
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/image/load_test.go
+++ b/image/load_test.go
@@ -23,7 +23,7 @@ func TestLoad(t *testing.T) {
 	assert.NilError(t, err, "expected pulling hello-world to succeed")
 
 	bundle, err := s.ExportBundle(ctx, func(config *image.ExportBundleConfig) {
-		config.Names = []string{"hello-world:latest"}
+		config.Names = []string{"hello-world:latest", "hello-world:latest"}
 	})
 	assert.NilError(t, err, "expected exporting hello-world to succeed")
 

--- a/image/load_test.go
+++ b/image/load_test.go
@@ -1,0 +1,34 @@
+package image_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/cpuguy83/go-docker/image"
+	"gotest.tools/assert"
+)
+
+func TestLoad(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+
+	// Create a dummy image that we can export.
+	err := s.Create(ctx, func(config *image.CreateConfig) {
+		config.FromImage = "hello-world"
+		config.Tag = "latest"
+		config.Repo = "dockerhub.io"
+	})
+	assert.NilError(t, err, "expected pulling hello-world to succeed")
+
+	bundle, err := s.ExportBundle(ctx, func(config *image.ExportBundleConfig) {
+		config.Names = []string{"hello-world:latest"}
+	})
+	assert.NilError(t, err, "expected exporting hello-world to succeed")
+
+	err = s.Load(ctx, io.NopCloser(bytes.NewReader(bundle)), func(config *image.LoadConfig) {
+		config.Quiet = true
+	})
+	assert.NilError(t, err, "expecting load to succeed")
+}

--- a/image/prune.go
+++ b/image/prune.go
@@ -1,0 +1,70 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cpuguy83/go-docker/httputil"
+	"github.com/cpuguy83/go-docker/image/imageapi"
+	"github.com/cpuguy83/go-docker/version"
+	"github.com/pkg/errors"
+)
+
+// PruneFilter represents filters to process on the prune list. See the official
+// docker docs for the meaning of each field
+// https://docs.docker.com/engine/api/v1.41/#operation/ImagePrune
+type PruneFilter struct {
+	Dangling []string `json:"dangling,omitempty"`
+	Label    []string `json:"label,omitempty"`
+	NotLabel []string `json:"label!,omitempty"`
+	Until    []string `json:"until,omitempty"`
+}
+
+// PruneConfig holds the options for pruning images.
+type PruneConfig struct {
+	Filters PruneFilter
+}
+
+// PruneOption is used as functional arguments to prune images. PruneOption
+// configure a PruneConfig.
+type PruneOption func(config *PruneConfig)
+
+// prune prunes container images.
+func (s *Service) Prune(ctx context.Context, opts ...PruneOption) (imageapi.Prune, error) {
+	cfg := PruneConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	withPruneConfig := func(req *http.Request) error {
+		q := req.URL.Query()
+		filterJSON, err := json.Marshal(cfg.Filters)
+		if err != nil {
+			return err
+		}
+		_ = filterJSON
+		q.Add("filters", string(filterJSON))
+		req.URL.RawQuery = q.Encode()
+		return nil
+	}
+
+	resp, err := httputil.DoRequest(ctx, func(ctx context.Context) (*http.Response, error) {
+		return s.tr.Do(ctx, http.MethodPost, version.Join(ctx, "/images/prune"), withPruneConfig)
+	})
+	if err != nil {
+		return imageapi.Prune{}, errors.Wrap(err, "pruning images")
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return imageapi.Prune{}, err
+	}
+	var prune imageapi.Prune
+	if err := json.Unmarshal(data, &prune); err != nil {
+		return imageapi.Prune{}, errors.Wrap(err, "reading response body")
+	}
+	return prune, nil
+}

--- a/image/prune_test.go
+++ b/image/prune_test.go
@@ -1,0 +1,106 @@
+package image_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cpuguy83/go-docker/image"
+	"github.com/cpuguy83/go-docker/image/imageapi"
+	"gotest.tools/assert"
+)
+
+func TestPrune(t *testing.T) {
+	ctx := context.Background()
+	s := newTestService(t)
+
+	buildContainers := func(t *testing.T) {
+		buildContainer(t, "test-image:positive", "test-image", "positive=true")
+		buildContainer(t, "test-image:negative", "test-image", "positive=false")
+		// Add a dummy image that should never be discovered in the tests below.
+		// In particualar, this tests that the interaction between Label and
+		// NotLabel filter works as intended.
+		buildContainer(t, "other-image:all", "other-image")
+	}
+	cleanup := func(t *testing.T) {
+		_, err := s.Prune(ctx, func(config *image.PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"test-image"}
+		})
+		assert.NilError(t, err)
+		_, err = s.Prune(ctx, func(config *image.PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"other-image"}
+		})
+		assert.NilError(t, err)
+	}
+
+	extract := func(prune imageapi.Prune) []string {
+		var l []string
+		for _, deleted := range prune.ImagesDeleted {
+			if deleted.Untagged != "" {
+				l = append(l, deleted.Untagged)
+			}
+		}
+		sort.Strings(l)
+		return l
+	}
+
+	t.Run("all", func(t *testing.T) {
+		buildContainers(t)
+		defer cleanup(t)
+
+		rep, err := s.Prune(ctx, func(config *image.PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"test-image"}
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, extract(rep), []string{"test-image:negative", "test-image:positive"})
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		buildContainers(t)
+		defer cleanup(t)
+
+		rep, err := s.Prune(ctx, func(config *image.PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"positive=true"}
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, extract(rep), []string{"test-image:positive"})
+	})
+
+	t.Run("non-positive", func(t *testing.T) {
+		buildContainers(t)
+		defer cleanup(t)
+
+		rep, err := s.Prune(ctx, func(config *image.PruneConfig) {
+			config.Filters.Dangling = []string{"false"}
+			config.Filters.Label = []string{"test-image"}
+			config.Filters.NotLabel = []string{"positive=true"}
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, extract(rep), []string{"test-image:negative"})
+	})
+}
+
+// buildContainer builds the container by executing the docker CLI until we have
+// extended the image service to provide the build endpoint.
+func buildContainer(t *testing.T, tag string, labels ...string) {
+	dockerfile := `FROM scratch
+CMD ["hello"]
+`
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0666))
+
+	args := []string{"build", dir, "--tag=" + tag}
+	for _, label := range labels {
+		args = append(args, "--label="+label)
+	}
+
+	rep, err := exec.Command("docker", args...).CombinedOutput()
+	assert.NilError(t, err, string(rep))
+}


### PR DESCRIPTION
Add support for loading and pruning docker images in the imageservice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/go-docker/3)
<!-- Reviewable:end -->
